### PR TITLE
fixed fork() bug on windows machines

### DIFF
--- a/lib/redmine_git_remote/poor_mans_capture3.rb
+++ b/lib/redmine_git_remote/poor_mans_capture3.rb
@@ -15,12 +15,11 @@ module RedmineGitRemote
       rout, wout = IO.pipe
       rerr, werr = IO.pipe
 
-      pid = fork do
+      pid = Process.spawn(*cmd) do
         rerr.close
         rout.close
         STDERR.reopen(werr)
         STDOUT.reopen(wout)
-        exec(*cmd)
       end
 
       wout.close


### PR DESCRIPTION
Fixes #22, a windows-specific bug because fork() is not available on windows machines, so spawn() is used instead
