### PR TITLE
Clone path setting

### DIFF
--- a/app/models/repository/git_remote.rb
+++ b/app/models/repository/git_remote.rb
@@ -6,9 +6,6 @@ require_dependency 'redmine_git_remote/poor_mans_capture3'
 
 class Repository::GitRemote < Repository::Git
 
-  PLUGIN_ROOT = Pathname.new(__FILE__).join("../../../..").realpath.to_s
-  PATH_PREFIX = PLUGIN_ROOT + "/repos/"
-
   before_validation :initialize_clone
 
   safe_attributes 'extra_info', :if => lambda {|repository, _user| repository.new_record?}
@@ -81,7 +78,11 @@ class Repository::GitRemote < Repository::Git
 
     p = parse(attributes["extra_info"]["extra_clone_url"])
     self.identifier = p[:identifier] if identifier.empty?
-    self.url = PATH_PREFIX + p[:path] if url.empty?
+
+    base_path = Setting.plugin_redmine_git_remote['git_remote_repo_clone_path']
+    base_path = base_path + "/" unless base_path.end_with?("/")
+
+    self.url = base_path + p[:path] if url.empty?
 
     err = ensure_possibly_empty_clone_exists
     errors.add :extra_clone_url, err if err

--- a/app/views/settings/_git_remote_settings.html.erb
+++ b/app/views/settings/_git_remote_settings.html.erb
@@ -1,0 +1,7 @@
+<h3><%= t('config.title') %></h3>
+
+<p>
+  <label><%= t('config.repo_clone_path') %></label>
+  <%= text_field_tag 'settings[git_remote_repo_clone_path]', @settings['git_remote_repo_clone_path'], :size => '60' %>
+  <%= t('config.clone_path_hint') %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,7 @@ en:
   field_extra_clone_url: Clone URL
   text_git_remote_url_note: The URL to clone from.
   text_git_remote_path_note: The absolute filesystem path to clone to. Leave blank to auto-populate from URL.
+  config:
+    title: Git Remote Settings
+    repo_clone_path: Repository clone path
+    clone_path_hint: Path where repository is cloned. Relative to plugin directory.

--- a/init.rb
+++ b/init.rb
@@ -9,4 +9,8 @@ Redmine::Plugin.register :redmine_git_remote do
   url 'https://github.com/dergachev/redmine_git_remote'
   description 'Automatically clone and fetch remote git repositories'
   version '0.0.1'
+
+  settings :default => {
+    'git_remote_repo_clone_path' => Pathname.new(__FILE__).join("../").realpath.to_s + "/repos",
+  }, :partial => 'settings/git_remote_settings'
 end

--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :redmine_git_remote do
   author 'Alex Dergachev'
   url 'https://github.com/dergachev/redmine_git_remote'
   description 'Automatically clone and fetch remote git repositories'
-  version '0.0.1'
+  version '0.0.2'
 
   settings :default => {
     'git_remote_repo_clone_path' => Pathname.new(__FILE__).join("../").realpath.to_s + "/repos",


### PR DESCRIPTION
Make repository clone path configurable via plugin configuration page. This PR adds a settings view where the user can set its preferred path. 
This is useful if Redmine is run entirely in a Container environment, with no volume mount for plugins.
If no setting is supplied, it will take the default path `repos` relative to plugins dir.

In addition I increased version to 0.0.2.